### PR TITLE
Force Chrome to use software rendering

### DIFF
--- a/test-puppeteer-xvfb.js
+++ b/test-puppeteer-xvfb.js
@@ -15,7 +15,8 @@ const puppeteer = require('puppeteer');
     headless: false,
     args: [
       '--window-size=1440,810',
-      '--window-position=0,0'
+      '--window-position=0,0',
+      '--use-gl=osmesa',
     ]
   });
 


### PR DESCRIPTION
Hi @GavinJoyce, thanks for these scripts.

I had to add `--use-gl=osmesa` to the Chromium arguments for puppeteer, otherwise I got this error message:

```
libGL error: failed to load driver: swrast
```

and Chrome would not render anything inside the xvfb screen, just a blank gray window.